### PR TITLE
chore: commitlint 추가 설정(header-max-length, body-empty)

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,6 +1,8 @@
 {
   "extends": ["@commitlint/config-conventional"],
   "rules": {
-    "subject-case": [0]
+    "subject-case": [0],
+    "header-max-length": [2, "always", 50],
+    "body-empty": [2, "always"]
   }
 }


### PR DESCRIPTION
## 이슈 번호
<!-- closes #이슈_번호 로 이슈를 닫아주세요. -->

closes #12 

## 구현(수정) 내용
<!-- 구현 혹은 버그 수정 내용을 상세히 나누어 적어주세요. -->

 * git commit message의 header를 50자로 제한.
 * git commit message의 body를 금지함.

## 스크린샷
<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->

### body가 존재할 때 

![image](https://github.com/prgrms-fe-devcourse/FEDC4_Campers_Jaeho/assets/66409882/43e90962-e0cf-4f21-b011-e232da81c295)

### header 길이가 50을 넘었을 때

![image](https://github.com/prgrms-fe-devcourse/FEDC4_Campers_Jaeho/assets/66409882/32ab1fe8-1d85-4fa3-8038-337580906bc6)


## PR 포인트 및 궁금한 점
<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->

