### PR TITLE
feat: 메인페이지 무한스크롤 구현

### DIFF
--- a/src/components/ContentList.tsx
+++ b/src/components/ContentList.tsx
@@ -1,0 +1,59 @@
+import { SimpleGrid, Box, Text } from '@chakra-ui/react';
+
+import { Link } from 'react-router-dom';
+import { ROUTES } from '../constants/routes';
+
+const ContentList = ({
+  contents,
+}: {
+  contents: { title: string; _id: string }[];
+}) => {
+  return (
+    <SimpleGrid w="100%" columns={2} spacing={2}>
+      {contents.map(({ title, _id }) => (
+        <Box
+          backgroundImage={'https://bit.ly/dan-abramov'}
+          backgroundRepeat="no-repeat"
+          backgroundSize="cover"
+          backgroundPosition="center"
+          height="30vh"
+          key={_id}
+          position="relative"
+          overflow="hidden"
+          borderRadius="10px"
+        >
+          <Box
+            position="relative"
+            w="100%"
+            h="100%"
+            background="linear-gradient(
+              180deg,
+              rgba(2, 0, 36, 0) 0%,
+              rgba(33, 33, 116, 0) 20%,
+              rgba(0, 0, 0, 1) 100%
+            )"
+          >
+            <Text position="absolute" bottom="50px" left="15px" color="grey">
+              북한
+            </Text>
+            <Text
+              position="absolute"
+              bottom="15px"
+              left="15px"
+              color="white"
+              fontSize="xl"
+            >
+              {title}
+            </Text>
+            <Link
+              to={`${ROUTES.USER_PROFILE}${_id}`}
+              style={{ position: 'absolute', width: '100%', height: '100%' }}
+            />
+          </Box>
+        </Box>
+      ))}
+    </SimpleGrid>
+  );
+};
+
+export default ContentList;

--- a/src/components/MainPageContent.tsx
+++ b/src/components/MainPageContent.tsx
@@ -1,0 +1,56 @@
+import { Spinner, Box, Text, Flex } from '@chakra-ui/react';
+import ContentList from './ContentList';
+import { useState, useRef, useCallback } from 'react';
+import useObserver from '../hooks/useObserver';
+import axios from 'axios';
+
+type contents = [] | { title: string; _id: string }[];
+
+export const axiosMainData = async (offset = 0, limit = 0) => {
+  return await axios.get(
+    `https://kdt.frontend.4th.programmers.co.kr:5009/posts/channel/64f806ccb3b4d210bb7b4fcb?offset=${offset}&limit=${limit}`
+  );
+};
+
+function MainPageContent() {
+  const ObserveRef = useObserver(() => {
+    addContent();
+  });
+  const [contents, setContents] = useState<contents>([]);
+  const [noMoreContent, setNoMoreContent] = useState<boolean>(false);
+  const contentAddCount = useRef<number>(0);
+
+  const addContent = useCallback(async (limit = 6) => {
+    if (noMoreContent) return;
+    const { data } = await axiosMainData(
+      contentAddCount.current * limit,
+      limit
+    );
+    setContents((prevContents) => [...prevContents, ...data]);
+    contentAddCount.current++;
+    if (data.length !== limit) setNoMoreContent(true);
+  }, []);
+
+  return (
+    <>
+      <Flex
+        flexDirection="column"
+        position="relative"
+        padding="15px 15px 50px 15px"
+      >
+        <ContentList contents={contents} />
+        <div ref={ObserveRef as React.MutableRefObject<HTMLDivElement>}></div>
+        <Box w="100%" p={'20px'} textAlign={'center'}>
+          {noMoreContent ? (
+            <Text fontSize="xl" fontWeight={'bold'}>
+              더 이상 게시물이 없습니다
+            </Text>
+          ) : (
+            <Spinner />
+          )}
+        </Box>
+      </Flex>
+    </>
+  );
+}
+export default MainPageContent;

--- a/src/hooks/useObserver.tsx
+++ b/src/hooks/useObserver.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react';
+
+const useObserver = (showEvent = () => console.log('show!')) => {
+  const ref = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver((e) => {
+      if (e[0].isIntersecting) showEvent();
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return ref;
+};
+
+export default useObserver;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,6 +1,6 @@
 import { SearchIcon } from '@chakra-ui/icons';
 import { Flex, Text } from '@chakra-ui/react';
-// import MainPageContent from '../components/MainPageContent';
+import MainPageContent from '../components/MainPageContent';
 // import BottomNavBar from '../components/BottomNavbar';
 
 function Main() {
@@ -19,9 +19,9 @@ function Main() {
         />
       </Flex>
 
-      {/* <MainPageContent />
+      <MainPageContent />
 
-      <BottomNavBar /> */}
+      {/* <BottomNavBar /> */}
     </>
   );
 }

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,0 +1,29 @@
+import { SearchIcon } from '@chakra-ui/icons';
+import { Flex, Text } from '@chakra-ui/react';
+// import MainPageContent from '../components/MainPageContent';
+// import BottomNavBar from '../components/BottomNavbar';
+
+function Main() {
+  return (
+    <>
+      <Flex height="60px" padding="0 15px" alignItems="center">
+        <Text fontSize="24px" flexGrow="1">
+          Campers
+        </Text>
+        {/* 검색페이지로 라우트 */}
+        <SearchIcon
+          boxSize={8}
+          cursor="pointer"
+          padding="5px"
+          borderRadius="15px"
+        />
+      </Flex>
+
+      {/* <MainPageContent />
+
+      <BottomNavBar /> */}
+    </>
+  );
+}
+
+export default Main;


### PR DESCRIPTION
## 이슈 번호
<!-- closes #이슈_번호로 이슈를 닫아주세요. -->

closes #50

## 구현(수정) 내용
<!-- 구현 혹은 버그 수정 내용을 상세히 나누어 적어주세요. -->

* useObserver 훅을 만들었습니다.
* Mainpage의 전체적인 레이아웃을 작성하였습니다.
* useObserver를 이용하여 Mainpage 에서 무한스크롤을 구현하였습니다.

페이지 스크롤 기준점이 화면에 보일 떄마다 api 를 호출하여 데이터를 추가하는 방식입니다. 데이터가 더 이상 없다고 판단되면 (호출한 개수만큼 데이터가 받아와지지 않았다면) 더 이상 데이터를 가져오지 않습니다.
## 스크린샷
<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->


## PR 포인트 및 궁금한 점
<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->

