### PR TITLE
feat: Auth 내부 SignIn, SignUp에 api 연결 및 예외 처리 

### DIFF
--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -1,14 +1,13 @@
-import { useForm } from 'react-hook-form';
 import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
 import { ButtonGroup, Text } from '@chakra-ui/react';
 import PrimaryButton from './common/PrimaryButton';
 import AuthInputField from './Auth/AuthInputField';
+import { useNavigate } from 'react-router-dom';
+import { signin } from '../apis/auth';
+import { setLocalStorage } from '../utils/storage';
 import passwordValidation from '../utils/passwordValidation';
-
-type SignInFormValues = {
-  signInEmail: string;
-  signInPassword: string;
-};
+import { SignInValues as SignInFormValues } from '../types/auth';
 
 const SignIn = () => {
   const {
@@ -18,18 +17,32 @@ const SignIn = () => {
     formState: { errors },
     reset,
   } = useForm<SignInFormValues>();
+  const navigate = useNavigate();
 
-  const onSubmit = (data: SignInFormValues) => {
-    console.log(data);
+  const onSubmit = async (data: SignInFormValues) => {
+    const response = await signin(data);
 
-    reset();
+    if (typeof response === 'string') {
+      alert('이메일 혹은 비밀번호가 잘못되었습니다');
+      setFocus('email');
+      reset();
+
+      return;
+    }
+
+    if (typeof response === 'object') {
+      const { token } = response;
+
+      setLocalStorage('token', token);
+      navigate('/');
+    }
   };
 
   const registers = {
-    signInEmail: register('signInEmail', {
+    email: register('email', {
       required: '이메일은 필수 입력입니다.',
     }),
-    signInPassword: register('signInPassword', {
+    password: register('password', {
       required: '비밀번호 입력은 필수입니다.',
       minLength: {
         value: 8,
@@ -40,32 +53,32 @@ const SignIn = () => {
   };
 
   useEffect(() => {
-    setFocus('signInEmail');
+    setFocus('email');
   }, [setFocus]);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <AuthInputField
-        {...registers.signInEmail}
-        error={errors.signInEmail}
-        id={'signin-email'}
-        label={'이메일'}
-        placeholder={'이메일을 입력해주세요'}
+        {...registers.email}
+        error={errors.email}
+        id="signin-email"
+        label="이메일"
+        placeholder="이메일을 입력해주세요"
       />
       <AuthInputField
-        {...registers.signInPassword}
-        error={errors.signInPassword}
-        id={'signin-password'}
-        label={'비밀번호'}
-        placeholder={'비밀번호를 입력해주세요'}
+        {...registers.password}
+        error={errors.password}
+        id="signin-password"
+        label="비밀번호"
+        placeholder="비밀번호를 입력해주세요"
         isPassword
       >
-        <Text fontSize={'xs'} color={'blackAlpha.600'}>
+        <Text fontSize="xs" color="blackAlpha.600">
           비밀번호는 8자 이상이면서 특수문자(!, @, #, $, %, ^, &, *, (, )), 영어
           대소문자, 숫자는 각각 최소 1개 이상 있어야합니다.
         </Text>
       </AuthInputField>
-      <ButtonGroup my={2} justifyContent={'center'} width="100%">
+      <ButtonGroup my={2} justifyContent="center" width="100%">
         <PrimaryButton type="submit">로그인</PrimaryButton>
         <PrimaryButton onClick={() => reset()}>초기화</PrimaryButton>
       </ButtonGroup>

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -1,35 +1,49 @@
 import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 import { ButtonGroup, Text } from '@chakra-ui/react';
 import PrimaryButton from './common/PrimaryButton';
 import AuthInputField from './Auth/AuthInputField';
+import { signup } from '../apis/auth';
 import passwordValidation from '../utils/passwordValidation';
-
-type SignUpFormValues = {
-  signUpEmail: string;
-  signUpPassword: string;
-  signUpPasswordConfirm: string;
-  signUpNickname: string;
-};
+import { setLocalStorage } from '../utils/storage';
+import { SignUpValues as SignUpFormValues } from '../types/auth';
 
 const SignUp = () => {
   const {
-    handleSubmit,
     register,
+    handleSubmit,
+    setFocus,
     formState: { errors },
     reset,
   } = useForm<SignUpFormValues>();
+  const navigate = useNavigate();
 
-  const onSubmit = (data: SignUpFormValues) => {
-    console.log(data);
+  const onSubmit = async (data: SignUpFormValues) => {
+    const response = await signup(data);
 
-    reset();
+    if (typeof response === 'string') {
+      alert('이미 존재하는 이메일입니다');
+      setFocus('email');
+      reset({
+        email: '',
+      });
+
+      return;
+    }
+
+    if (typeof response === 'object') {
+      const { token } = response;
+
+      setLocalStorage('token', token);
+      navigate('/');
+    }
   };
 
   const registers = {
-    signUpEmail: register('signUpEmail', {
-      required: '이메일 입력을 필수입니다',
+    email: register('email', {
+      required: '이메일 입력은 필수입니다',
     }),
-    signUpPassword: register('signUpPassword', {
+    password: register('password', {
       required: '비밀번호는 8자 이상입니다',
       minLength: {
         value: 8,
@@ -37,16 +51,12 @@ const SignUp = () => {
       },
       validate: passwordValidation,
     }),
-    signUpPasswordConfirm: register('signUpPasswordConfirm', {
+    passwordConfirm: register('passwordConfirm', {
       required: '재확인 비밀번호를 입력해주세요',
-      validate: (
-        _: string,
-        { signUpPassword, signUpPasswordConfirm }: SignUpFormValues
-      ) =>
-        signUpPassword === signUpPasswordConfirm ||
-        '비밀번호가 일치하지 않습니다',
+      validate: (_: string, { password, passwordConfirm }: SignUpFormValues) =>
+        password === passwordConfirm || '비밀번호가 일치하지 않습니다',
     }),
-    signUpNickname: register('signUpNickname', {
+    fullName: register('fullName', {
       required: '',
       minLength: {
         value: 2,
@@ -58,41 +68,41 @@ const SignUp = () => {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <AuthInputField
-        {...registers.signUpEmail}
-        error={errors.signUpEmail}
-        id={'signup-email'}
-        label={'이메일'}
-        placeholder={'이메일을 형식에 맞게 입력해주세요'}
+        {...registers.email}
+        error={errors.email}
+        id="signup-email"
+        label="이메일"
+        placeholder="이메일을 형식에 맞게 입력해주세요"
       />
       <AuthInputField
-        {...registers.signUpPassword}
-        error={errors.signUpPassword}
-        id={'signup-password'}
-        label={'비밀번호'}
-        placeholder={'비밀번호를 형식에 맞게 입력해주세요'}
+        {...registers.password}
+        error={errors.password}
+        id="signup-password"
+        label="비밀번호"
+        placeholder="비밀번호를 형식에 맞게 입력해주세요"
         isPassword
       >
-        <Text fontSize={'xs'} color={'blackAlpha.600'}>
+        <Text fontSize="xs" color="blackAlpha.600">
           비밀번호는 8자 이상이면서 특수문자(!, @, #, $, %, ^, &, *, (, )), 영어
           대소문자, 숫자는 각각 최소 1개 이상 있어야합니다.
         </Text>
       </AuthInputField>
       <AuthInputField
-        {...registers.signUpPasswordConfirm}
-        error={errors.signUpPasswordConfirm}
-        id={'signup-password-confirm'}
-        label={'비밀번호 확인'}
-        placeholder={'비밀번호를 다시 입력해주세요'}
+        {...registers.passwordConfirm}
+        error={errors.passwordConfirm}
+        id="signup-password-confirm"
+        label="비밀번호 확인"
+        placeholder="비밀번호를 다시 입력해주세요"
         isPassword
       />
       <AuthInputField
-        {...registers.signUpNickname}
-        error={errors.signUpNickname}
-        id={'signup-nickname'}
-        label={'닉네임'}
-        placeholder={'닉네임을 2자 이상 입력해주세요'}
+        {...registers.fullName}
+        error={errors.fullName}
+        id="signup-nickname"
+        label="닉네임"
+        placeholder="닉네임을 2자 이상 입력해주세요"
       />
-      <ButtonGroup my={2} justifyContent={'center'} width="100%">
+      <ButtonGroup my={2} justifyContent="center" width="100%">
         <PrimaryButton type="submit">회원가입</PrimaryButton>
         <PrimaryButton onClick={() => reset()}>초기화</PrimaryButton>
       </ButtonGroup>


### PR DESCRIPTION
## 이슈 번호
<!-- closes #이슈_번호 로 이슈를 닫아주세요. -->

closes #102 

## 구현(수정) 내용
<!-- 구현 혹은 버그 수정 내용을 상세히 나누어 적어주세요. -->

Auth 구성 컴포넌트인 SignIn, SignUp에 api 연결 후,
로그인시 이메일이 없거나 이메일과 비밀번호가 일치하지 않은 케이스 예외처리
회원가입시 이메일이 중복되는 케이스 예외처리

* [feat: SignUp에 api 연결 후 예외 처리](https://github.com/prgrms-fe-devcourse/FEDC4_Campers_Jaeho/commit/a2653dd26ab33f19391abce6766ff26e66474150)
* [feat: SignIn에 api 연결 후 예외 처리](https://github.com/prgrms-fe-devcourse/FEDC4_Campers_Jaeho/commit/f71887dd4e71100eaf75b0c0ed4dbfe1185ab756)

## 스크린샷
<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->



## PR 포인트 및 궁금한 점
<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->

예외처리를 할 때 우선 alert로 처리를 했습니다.
차후 chakra를 활용하여 개선하겠습니다!!
