### PR TITLE
feat: 로그인이 완료된 후의 Auth로 페이지 이동 막기

### DIFF
--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -34,6 +34,7 @@ const SignIn = () => {
       const { token } = response;
 
       setLocalStorage('token', token);
+      history.replaceState(null, '', '/');
       navigate('/');
     }
   };

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -35,6 +35,7 @@ const SignUp = () => {
       const { token } = response;
 
       setLocalStorage('token', token);
+      history.replaceState(null, '', '/');
       navigate('/');
     }
   };

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Text,
   Tabs,
@@ -10,24 +11,35 @@ import {
 } from '@chakra-ui/react';
 import SignIn from '../components/SignIn';
 import SignUp from '../components/SignUp';
+import { getLocalStorage } from '../utils/storage';
 
 const Auth = () => {
   const [tabIndex, setTabIndex] = useState(0);
+  const navigate = useNavigate();
 
   const handleTabsChange = (index: number) => {
     setTabIndex(index);
   };
 
+  useEffect(() => {
+    const token = getLocalStorage('token');
+
+    if (token.length) {
+      history.replaceState(null, '', '/');
+      navigate('/');
+    }
+  }, []);
+
   return (
     <Container
-      h={'100vh'}
+      h="100vh"
       centerContent
-      maxW={'container.sm'}
-      justifyContent={'center'}
+      maxW="container.sm"
+      justifyContent="center"
     >
       <Tabs minH={500} index={tabIndex} onChange={handleTabsChange}>
-        <TabList borderBottom={'none'} justifyContent={'center'}>
-          <Tab color={'green.400'}>
+        <TabList borderBottom="none" justifyContent="center">
+          <Tab color="green.400">
             <Text color={tabIndex === 0 ? 'green.400' : 'blackAlpha.600'}>
               로그인
             </Text>


### PR DESCRIPTION
## 이슈 번호
<!-- closes #이슈_번호 로 이슈를 닫아주세요. -->

closes #114 

## 구현(수정) 내용
<!-- 구현 혹은 버그 수정 내용을 상세히 나누어 적어주세요. -->

* [feat: 로그인 되어있는 경우 auth 이동 막기](https://github.com/prgrms-fe-devcourse/FEDC4_Campers_Jaeho/commit/32f2067741c2c0fb3f215017c2a39fc0f7765ad2)
* [feat: 로그인(회원가입) 후 히스토리 '/auth' 기록 '/'로 바꿈](https://github.com/prgrms-fe-devcourse/FEDC4_Campers_Jaeho/commit/93dd3d88976453b5574f3c74e5045282d83f8283)

## 스크린샷
<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->



## PR 포인트 및 궁금한 점
<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->

로그인이 된 후에는 토근을 받습니다. 그 상태로 auth페이지를 초기에 들어가던 path를 임의로 변경해서 들어가던 토큰이 존재하기 때문에 '/'로 돌아가게 하고 그 전에 auth를 거쳐가기 때문에 '/auth'의 기록을 '/'로 바꿉니다.

회원가입, 로그인 로직 또한 과정이 끝나면 '/auth' 히스토리를 '/'로 바꿉니다.