### PR TITLE
feat: userInfo에 알림창 추가

### DIFF
--- a/src/components/UserInfo.tsx
+++ b/src/components/UserInfo.tsx
@@ -67,16 +67,10 @@ const UserInfo = () => {
   const { error, data } = useQuery(['user-info', userId], () =>
     searchUser(userId!)
   );
+  const [notifications, setNotifications] = useState([]);
   const newNotification = useQuery(['noti', token], () =>
     axiosNotifications(token)
   ).data;
-  console.log(newNotification);
-
-  const [notifications, setNotifications] = useState([
-    { message: '리사님이 댓글을 달았습니다', _id: '1' },
-    { message: '제니님이 댓글을 달았습니다', _id: '2' },
-    { message: '로제님이 댓글을 달았습니다', _id: '3' },
-  ]);
 
   useEffect(() => {
     if (data) {

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -3,7 +3,7 @@ import UserInfo from '../components/UserInfo';
 
 const UserProfile = () => {
   return (
-    <Container maxW="sm" my={5}>
+    <Container>
       <UserInfo />
     </Container>
   );


### PR DESCRIPTION
## 이슈 번호
<!-- closes #이슈_번호 로 이슈를 닫아주세요. -->

closes #113

## 구현(수정) 내용
<!-- 구현 혹은 버그 수정 내용을 상세히 나누어 적어주세요. -->

* 알림목록을 볼 수 있는 알림창을 userinfo에 만들었습니다.
* 추가로 필요할 수 있는 기능 ( 
 1. 현재 페이지가 자신의 페이지일 때만 알림,수정 박스 보이게 하기.
 2. 알림을 클릭하면 관련 게시물, 채팅창으로 이동할 수 있게 하기.
 ) 이는 추가적으로 수정되어야 하는 사항입니다

****
또한 현재 스타일 문제로, 약 1000px 이상의 화면에서 모달창을 열시, 메인 화면이 이동하는 버그가 있습니다. 이에 대한 수정도 필요합니다. 



## 스크린샷
<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->



## PR 포인트 및 궁금한 점
<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->

