### PR TITLE
feat: PrimatyAlertDialogSet에 확인, 취소 실행시 동작 추가 및 UerProfile의 logout, Sign에 적용

### DIFF
--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -23,13 +23,17 @@ const SignIn = () => {
   const { setUserInfo } = useUserInfoContext();
   const { isOpen, onClose, onOpen } = useDisclosure();
 
+  const handleConfirm = () => {
+    onClose();
+    setFocus('email');
+    reset();
+  };
+
   const onSubmit = async (data: SignInFormValues) => {
     const response = await signin(data);
 
     if (typeof response === 'string') {
       onOpen();
-      setFocus('email');
-      reset();
 
       return;
     }
@@ -65,9 +69,14 @@ const SignIn = () => {
   return (
     <>
       <PrimaryAlertDialogSet
-        bodyContent="이메일 혹은 비밀번호가 잘못되었습니다"
+        bodyContentSentences={[
+          '이메일 혹은 비밀번호가 잘못되었습니다.',
+          '초기화하시겠습니까?',
+        ]}
         isOpen={isOpen}
         onClose={onClose}
+        hasCancelButton
+        handleConfirm={handleConfirm}
       />
       <form onSubmit={handleSubmit(onSubmit)}>
         <AuthInputFieldWithForm

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -22,15 +22,19 @@ const SignUp = () => {
   const { setUserInfo } = useUserInfoContext();
   const { isOpen, onClose, onOpen } = useDisclosure();
 
+  const handleConfirm = () => {
+    onClose();
+    setFocus('email');
+    reset({
+      email: '',
+    });
+  };
+
   const onSubmit = async (data: SignUpFormValues) => {
     const response = await signup(data);
 
     if (typeof response === 'string') {
       onOpen();
-      setFocus('email');
-      reset({
-        email: '',
-      });
 
       return;
     }
@@ -78,9 +82,14 @@ const SignUp = () => {
   return (
     <>
       <PrimaryAlertDialogSet
-        bodyContent="이미 존재하는 이메일입니다"
+        bodyContentSentences={[
+          '이미 존재하는 이메일입니다.',
+          '이메일을 초기화하시겠습니까?',
+        ]}
         isOpen={isOpen}
         onClose={onClose}
+        hasCancelButton
+        handleConfirm={handleConfirm}
       />
       <form onSubmit={handleSubmit(onSubmit)}>
         <AuthInputFieldWithForm

--- a/src/components/common/PrimaryAlertDialogSet.tsx
+++ b/src/components/common/PrimaryAlertDialogSet.tsx
@@ -57,7 +57,9 @@ const PrimaryAlertDialogSet = ({
           </AlertDialogHeader>
           <AlertDialogBody>
             {bodyContentSentences.map((bodyContentSentense, index) => (
-              <Text mt={index > 0 ? 1 : 0}>{bodyContentSentense}</Text>
+              <Text key={index} mt={index > 0 ? 1 : 0}>
+                {bodyContentSentense}
+              </Text>
             ))}
           </AlertDialogBody>
           <AlertDialogFooter>

--- a/src/components/common/PrimaryAlertDialogSet.tsx
+++ b/src/components/common/PrimaryAlertDialogSet.tsx
@@ -6,6 +6,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogOverlay,
+  Text,
 } from '@chakra-ui/react';
 import PrimaryButton from './PrimaryButton';
 
@@ -14,23 +15,27 @@ type MotionPreset = 'slideInBottom' | 'slideInRight' | 'scale';
 type PrimaryAlertDialogSetProps = {
   isOpen: boolean;
   onClose: () => void;
-  bodyContent: string;
+  bodyContentSentences: string[];
   headerContent?: string;
   hasOverlay?: boolean;
   hasCancelButton?: boolean;
   isCentered?: boolean;
   motionPreset?: MotionPreset;
+  handleConfirm: () => void;
+  handleCancel?: () => void;
 };
 
 const PrimaryAlertDialogSet = ({
   isOpen,
   onClose,
-  bodyContent,
+  bodyContentSentences,
   headerContent = '',
   hasOverlay = false,
   hasCancelButton = false,
   isCentered = false,
   motionPreset = 'scale',
+  handleConfirm,
+  handleCancel = onClose,
 }: PrimaryAlertDialogSetProps) => {
   const cancelRef = useRef<HTMLButtonElement | null>(null);
 
@@ -50,7 +55,11 @@ const PrimaryAlertDialogSet = ({
           <AlertDialogHeader fontSize="lg" fontWeight="bold">
             {headerContent}
           </AlertDialogHeader>
-          <AlertDialogBody>{bodyContent}</AlertDialogBody>
+          <AlertDialogBody>
+            {bodyContentSentences.map((bodyContentSentense, index) => (
+              <Text mt={index > 0 ? 1 : 0}>{bodyContentSentense}</Text>
+            ))}
+          </AlertDialogBody>
           <AlertDialogFooter>
             {hasCancelButton && (
               <PrimaryButton
@@ -58,12 +67,12 @@ const PrimaryAlertDialogSet = ({
                 bgColor="blackAlpha.400"
                 hoverBgColor="blackAlpha.500"
                 ref={cancelRef}
-                onClick={onClose}
+                onClick={handleCancel}
               >
                 취소
               </PrimaryButton>
             )}
-            <PrimaryButton onClick={onClose}>확인</PrimaryButton>
+            <PrimaryButton onClick={handleConfirm}>확인</PrimaryButton>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -23,6 +23,7 @@ import PrimaryText from '../components/common/PrimaryText';
 import { isSameUser } from '../utils/isSameUser';
 import PrimaryImage from '../components/common/PrimaryImage';
 import { logout } from '../apis/auth';
+import PrimaryAlertDialogSet from '../components/common/PrimaryAlertDialogSet';
 
 const UserProfile = () => {
   const navigate = useNavigate();
@@ -32,6 +33,11 @@ const UserProfile = () => {
   const [userName, setUserName] = useState('');
   const [isMyInfo, setIsMyInfo] = useState(false);
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const {
+    isOpen: isLogoutOpen,
+    onOpen: onLogoutOpen,
+    onClose: onLogoutClose,
+  } = useDisclosure();
   const { userId } = useParams();
   const { getSearchUser: { data, error } = {} } = useSearchUser(userId);
   const { data: notificationData } = useNotification();
@@ -41,10 +47,10 @@ const UserProfile = () => {
     setUserImage(file);
   };
 
-  const handleLogout = async () => {
-    await logout();
-    // alert
+  const handleLogoutConfirm = async () => {
+    onLogoutClose();
     setUserInfo(null);
+    await logout();
     navigate('/');
   };
 
@@ -73,6 +79,14 @@ const UserProfile = () => {
 
   return (
     <>
+      <PrimaryAlertDialogSet
+        bodyContentSentences={['로그아웃을 하시겠습니까?']}
+        isOpen={isLogoutOpen}
+        onClose={onLogoutClose}
+        hasCancelButton
+        hasOverlay
+        handleConfirm={handleLogoutConfirm}
+      />
       {data && notificationData ? (
         <>
           <PrimaryModal isOpen={isOpen} onClose={onClose}>
@@ -142,7 +156,7 @@ const UserProfile = () => {
                 />
               </Flex>
               {isMyInfo ? (
-                <PrimaryButton w="150px" onClick={handleLogout}>
+                <PrimaryButton w="150px" onClick={onLogoutOpen}>
                   로그아웃
                 </PrimaryButton>
               ) : (


### PR DESCRIPTION
## 이슈 번호
<!-- closes #이슈_번호 로 이슈를 닫아주세요. -->

closes #243 

## 구현(수정) 내용
<!-- 구현 혹은 버그 수정 내용을 상세히 나누어 적어주세요. -->

* [feat: bodyContent 여러 줄 가능, 확인, 취소 실행동작 추가](https://github.com/prgrms-fe-devcourse/FEDC4_Campers_Jaeho/commit/8d28374430896158c93d70c6308a11e0158fd40b)
* [feat: Sign(In, Up)에 수정된 AlertDialog 적용](https://github.com/prgrms-fe-devcourse/FEDC4_Campers_Jaeho/commit/2a5236de4b64ec6a41c6802a31be22049cd48dfe)
* [feat: UserProfile의 logout에 AlertDialog 적용](https://github.com/prgrms-fe-devcourse/FEDC4_Campers_Jaeho/commit/f33876fab8f5651e9c2e5c28be771ead9ec85dd9)

## 스크린샷
<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->


https://github.com/prgrms-fe-devcourse/FEDC4_Campers_Jaeho/assets/66409882/2e2b37e5-315f-4338-9d3d-5c85baefffba



## PR 포인트 및 궁금한 점
<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->

