### PR TITLE
fix: useColorModeValue 및 Input의 bgColor 제거

### DIFF
--- a/src/components/Auth/AuthInputFieldWithForm.tsx
+++ b/src/components/Auth/AuthInputFieldWithForm.tsx
@@ -8,7 +8,6 @@ import {
   InputRightElement,
   Text,
   useBoolean,
-  useColorModeValue,
 } from '@chakra-ui/react';
 import { ViewIcon, ViewOffIcon } from '@chakra-ui/icons';
 
@@ -23,7 +22,6 @@ const AuthInputFieldWithForm = forwardRef<
   AuthInputFieldWithFormProps
 >(({ message, label, helperTexts, type, id, ...inputProps }, ref) => {
   const [isShow, setIsShow] = useBoolean();
-  const textColor = useColorModeValue('#2D3748', 'white');
 
   return (
     <FormControl isRequired isInvalid={message ? true : false}>
@@ -36,7 +34,6 @@ const AuthInputFieldWithForm = forwardRef<
           id={id}
           ref={ref}
           type={type === 'password' ? (isShow ? 'text' : 'password') : type}
-          bgColor="gray.200"
         />
         {type === 'password' && (
           <InputRightElement onClick={() => setIsShow.toggle()}>
@@ -46,12 +43,7 @@ const AuthInputFieldWithForm = forwardRef<
       </InputGroup>
       {helperTexts &&
         helperTexts.map((helperText, index) => (
-          <Text
-            key={index}
-            fontSize="xs"
-            color={textColor}
-            wordBreak="keep-all"
-          >
+          <Text key={index} mt={2} fontSize="xs" wordBreak="keep-all">
             {helperText}
           </Text>
         ))}


### PR DESCRIPTION
## 이슈 번호
<!-- closes #이슈_번호 로 이슈를 닫아주세요. -->

* closes #324 

## 구현(수정) 내용
<!-- 구현 혹은 버그 수정 내용을 상세히 나누어 적어주세요. -->

* [fix: useColorModeValue 및 Input의 bgColor 제거](https://github.com/prgrms-fe-devcourse/FEDC4_Campers_Jaeho/commit/43ee9f2cf2217262c4de6a5477d646a259ac2c5d)

## 스크린샷
<!-- 구현 혹은 버그 수정 내용에 대한 스크린샷을 남겨주세요. -->



## PR 포인트 및 궁금한 점
<!-- PR에 대한 주요 포인트나 구현 혹은 버그 수정을 하다가 궁금했거나 애매했던 점을 적어주세요. -->

bgColor를 제거하여 기본적으로 다크모드와 라이트모드에서 동작하게 하였습니다!